### PR TITLE
Fix 'main' package.json entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name" : "chromath",
     "version" : "0.0.5",
     "description" : "JavaScript color conversion and manipulation functions",
-    "main" : "chromath.js",
+    "main" : "index.js",
     "repository" : {
         "type" : "git",
         "url" : "git://github.com/jfsiii/chromath.git"


### PR DESCRIPTION
Importing the module didn't work (at least with React Native) because the `main` key was still pointing to the old chromath.js file. Changing the value to index.js or omitting this key (npm looks for index.js by default) fixes the issue.
